### PR TITLE
fix: simulator build error and missing eslint config

### DIFF
--- a/template/.eslintrc.js
+++ b/template/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
   root: true,
   extends: ['@react-native-community', 'plugin:react/recommended', 'plugin:react-hooks/recommended'],
-  plugins: ['unused-imports'],
+  plugins: ['unused-imports', 'import'],
   rules: {
     semi: 'off',
     'comma-dangle': 'off',

--- a/template/ios/Podfile
+++ b/template/ios/Podfile
@@ -32,6 +32,11 @@ target 'RNBaseProject' do
   end
 
   post_install do |installer|
+    installer.pods_project.targets.each do |target|
+      target.build_configurations.each do |config|
+        config.build_settings['EXCLUDED_ARCHS[sdk=iphonesimulator*]'] = "arm64"
+      end
+    end
     react_native_post_install(
       installer,
       # Set `mac_catalyst_enabled` to `true` in order to apply patches


### PR DESCRIPTION
## Summary
Fixing error:
- [x] cannot build on simulator 
- [x] missing configuration for eslint

## Error
- Build error on Terminal
<img width="500" alt="Screen Shot 2023-01-13 at 01 24 26" src="https://user-images.githubusercontent.com/114563576/212152275-7932ad7d-25ef-4ca0-9c93-67c8b6c2e409.png">

- Build error on XCode
<img width="500" alt="Screen Shot 2023-01-13 at 01 12 38" src="https://user-images.githubusercontent.com/114563576/212152499-dc34e913-5fce-47b4-a5cc-0cb4129d74b8.png">

